### PR TITLE
Crash on dismissing UIActionSheet’s 

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -362,8 +362,8 @@ static NSUInteger PSPDFVisibleAlertsCount = 0;
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Execute Actions
 
-- (PSTAlertAction *)actionForButtonIndex:(NSUInteger)index {
-    return self.actions[index];
+- (PSTAlertAction *)actionForButtonIndex:(NSInteger)index {
+    return (index >= 0) ? self.actions[index] : nil;
 }
 
 - (void)performBlocks:(NSString *)blocksStorageName withAction:(PSTAlertAction *)alertAction {


### PR DESCRIPTION
UIActionSheet’s willDismissWithButtonIndex returns with index -1

I got this really odd crash when dismissing a action sheet by pressing outside of it

Method:

```
- (PSTAlertAction *)actionForButtonIndex:(NSUInteger)index {
    return self.actions[index];
}
```

Stacktrace:

```
2014-11-21 13:11:15.771 AppName[68263:613] *** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayI objectAtIndex:]: index 18446744073709551615 beyond bounds [0 .. 0]'
*** First throw call stack:
(
    0   CoreFoundation                      0x000000010dc65495 __exceptionPreprocess + 165
    1   libobjc.A.dylib                     0x000000010d9c099e objc_exception_throw + 43
    2   CoreFoundation                      0x000000010dc1de3f -[__NSArrayI objectAtIndex:] + 175
    3   MineAnsatte-Beta                    0x000000010b2f811c -[PSTAlertController actionForButtonIndex:] + 76
    4   MineAnsatte-Beta                    0x000000010b2f84be -[PSTAlertController viewWillDismissWithButtonIndex:] + 62
    5   MineAnsatte-Beta                    0x000000010b2f86ab -[PSTAlertController actionSheet:willDismissWithButtonIndex:] + 107
    6   UIKit                               0x000000010ce37a14 -[UIActionSheet dismissWithClickedButtonIndex:animated:] + 367
    7   UIKit                               0x000000010cf1cef9 __73-[UIPopoverController _completionBlockForDismissalWhenNotifyingDelegate:]_block_invoke + 405
    8   UIKit                               0x000000010ca2a6e8 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 299
    9   UIKit                               0x000000010ca1668e -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 235
    10  UIKit                               0x000000010ca16941 -[UIViewAnimationState animationDidStop:finished:] + 78
    11  UIKit                               0x000000011b96d4b7 -[UIViewAnimationStateAccessibility(SafeCategory) animationDidStop:finished:] + 48
    12  QuartzCore                          0x000000010c662134 _ZN2CA5Layer23run_animation_callbacksEPv + 310
    13  libdispatch.dylib                   0x000000010fa8b72d _dispatch_client_callout + 8
    14  libdispatch.dylib                   0x000000010fa7b3fc _dispatch_main_queue_callback_4CF + 354
    15  CoreFoundation                      0x000000010dcc3289 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
```

I caught that 

```
- (void)actionSheet:(UIActionSheet *)actionSheet willDismissWithButtonIndex:(NSInteger)buttonIndex {
    [self viewWillDismissWithButtonIndex:buttonIndex];
}
```

Is returning buttonIndex: -1 when you tap outside the popover in an actionSheet and that you were using NSUInteger instead of NSInteger.
