### PR TITLE
add better iPad popover support

### DIFF
--- a/Example/PSTAlertViewControllerSample.xcodeproj/project.pbxproj
+++ b/Example/PSTAlertViewControllerSample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		78E298941A0D0071007953FB /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 78E298931A0D0071007953FB /* Images.xcassets */; };
 		78E298971A0D0071007953FB /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 78E298951A0D0071007953FB /* LaunchScreen.xib */; };
 		78E298B21A0D0B25007953FB /* PSTAlertController.m in Sources */ = {isa = PBXBuildFile; fileRef = 78E298B11A0D0B25007953FB /* PSTAlertController.m */; };
+		B87AF4971A67D76C00022878 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B87AF4961A67D76C00022878 /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		78E298A21A0D0071007953FB /* PSTAlertViewControllerSampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PSTAlertViewControllerSampleTests.m; sourceTree = "<group>"; };
 		78E298B01A0D0B25007953FB /* PSTAlertController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PSTAlertController.h; sourceTree = "<group>"; };
 		78E298B11A0D0B25007953FB /* PSTAlertController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PSTAlertController.m; sourceTree = "<group>"; };
+		B87AF4961A67D76C00022878 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -38,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B87AF4971A67D76C00022878 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -47,6 +50,7 @@
 		78E2987A1A0D0071007953FB = {
 			isa = PBXGroup;
 			children = (
+				B87AF4961A67D76C00022878 /* UIKit.framework */,
 				78E298851A0D0071007953FB /* PSTAlertViewControllerSample */,
 				78E2989F1A0D0071007953FB /* PSTAlertViewControllerSampleTests */,
 				78E298841A0D0071007953FB /* Products */,

--- a/Example/PSTAlertViewControllerSample/Base.lproj/Main.storyboard
+++ b/Example/PSTAlertViewControllerSample/Base.lproj/Main.storyboard
@@ -1,25 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAa-Py-WRi">
+                                <rect key="frame" x="183" y="54" width="46" height="30"/>
+                                <state key="normal" title="test AlertController">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <variation key="heightClass=regular" fixedFrame="YES">
+                                    <rect key="frame" x="320" y="497" width="129" height="30"/>
+                                </variation>
+                                <connections>
+                                    <action selector="testButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1TS-0W-adq"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="iPad"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="280" y="361"/>
         </scene>
     </scenes>
 </document>

--- a/Example/PSTAlertViewControllerSample/ViewController.h
+++ b/Example/PSTAlertViewControllerSample/ViewController.h
@@ -10,6 +10,5 @@
 
 @interface ViewController : UIViewController
 
-
 @end
 

--- a/Example/PSTAlertViewControllerSample/ViewController.m
+++ b/Example/PSTAlertViewControllerSample/ViewController.m
@@ -13,8 +13,14 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+}
 
-    [self doTheDance];
+- (IBAction)testButtonPressed:(UIButton *)sender {
+    PSTAlertController *controller = [PSTAlertController actionSheetWithTitle:nil];
+    [controller addAction:[PSTAlertAction actionWithTitle:@"OK" style:PSTAlertActionStyleDestructive handler:nil]];
+    // Cancel action on a sheet should be the last action.
+    [controller addAction:[PSTAlertAction actionWithTitle:@"cancel" style:PSTAlertActionStyleCancel handler:nil]];
+    [controller showWithSender:sender arrowDirection:UIPopoverArrowDirectionAny controller:self animated:YES completion:nil];
 }
 
 - (void)doTheDance {

--- a/PSTAlertController/PSTAlertController.h
+++ b/PSTAlertController/PSTAlertController.h
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSInteger, PSTAlertActionStyle) {
 
 // Presentation and dismissal
 - (void)showWithSender:(id)sender controller:(UIViewController *)controller animated:(BOOL)animated completion:(void (^)(void))completion;
+- (void)showWithSender:(id)sender arrowDirection:(UIPopoverArrowDirection)arrowDirection controller:(UIViewController *)controller animated:(BOOL)animated completion:(void (^)(void))completion;
 - (void)dismissAnimated:(BOOL)animated completion:(void (^)(void))completion;
 
 + (BOOL)hasVisibleAlertController;

--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -243,6 +243,10 @@ static NSUInteger PSTVisibleAlertsCount = 0;
 }
 
 - (void)showWithSender:(id)sender controller:(UIViewController *)controller animated:(BOOL)animated completion:(void (^)(void))completion {
+    [self showWithSender:sender arrowDirection:UIPopoverArrowDirectionAny controller:controller animated:animated completion:completion];
+}
+
+- (void)showWithSender:(id)sender arrowDirection:(UIPopoverArrowDirection)arrowDirection controller:(UIViewController *)controller animated:(BOOL)animated completion:(void (^)(void))completion {
     if ([self alertControllerAvailable]) {
         // As a convenience, allow automatic root view controller fetching if we show an alert.
         if (self.preferredStyle == PSTAlertControllerStyleAlert) {
@@ -285,9 +289,22 @@ static NSUInteger PSTVisibleAlertsCount = 0;
             // Workaround for rdar://18921595. Unsatisfiable constraints when presenting UIAlertController.
             // If the rect is too large, the action sheet can't be displayed.
             CGRect r = popoverPresentation.sourceRect, screen = UIScreen.mainScreen.bounds;
-            if (CGRectGetHeight(r) > CGRectGetHeight(screen)*0.5 || CGRectGetWidth(r) > CGRectGetWidth(screen)*0.5) {
-                popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y + r.size.height/2.f, 1.f, 1.f);
-            }
+            UIPopoverPresentationController *popover = controller.popoverPresentationController;
+                popover.permittedArrowDirections = arrowDirection;
+                switch (arrowDirection) {
+                    case UIPopoverArrowDirectionDown:
+                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2, r.origin.y, 1, 1);
+                        break;
+                    case UIPopoverArrowDirectionUp:
+                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2, r.origin.y + r.size.height, 1, 1);
+                        break;
+                    // Left and right is too buggy.
+                    default:
+                        if (CGRectGetHeight(r) > CGRectGetHeight(screen)*0.5 || CGRectGetWidth(r) > CGRectGetWidth(screen)*0.5) {
+                            popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y + r.size.height/2.f, 1.f, 1.f);
+                        }
+                        break;
+                }
         }
 
         // Hook up dismiss blocks.

--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -289,20 +289,22 @@ static NSUInteger PSTVisibleAlertsCount = 0;
             // Workaround for rdar://18921595. Unsatisfiable constraints when presenting UIAlertController.
             // If the rect is too large, the action sheet can't be displayed.
             CGRect r = popoverPresentation.sourceRect, screen = UIScreen.mainScreen.bounds;
+            if (CGRectGetHeight(r) > CGRectGetHeight(screen)*0.5 || CGRectGetWidth(r) > CGRectGetWidth(screen)*0.5) {
+                popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y + r.size.height/2.f, 1.f, 1.f);
+            }
+
+            // optimize arrow positioning for up and down.
             UIPopoverPresentationController *popover = controller.popoverPresentationController;
                 popover.permittedArrowDirections = arrowDirection;
                 switch (arrowDirection) {
                     case UIPopoverArrowDirectionDown:
-                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2, r.origin.y, 1, 1);
+                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y, 1.f, 1.f);
                         break;
                     case UIPopoverArrowDirectionUp:
-                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2, r.origin.y + r.size.height, 1, 1);
+                        popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y + r.size.height, 1.f, 1.f);
                         break;
                     // Left and right is too buggy.
                     default:
-                        if (CGRectGetHeight(r) > CGRectGetHeight(screen)*0.5 || CGRectGetWidth(r) > CGRectGetWidth(screen)*0.5) {
-                            popoverPresentation.sourceRect = CGRectMake(r.origin.x + r.size.width/2.f, r.origin.y + r.size.height/2.f, 1.f, 1.f);
-                        }
                         break;
                 }
         }


### PR DESCRIPTION
This adds correct positioning for arrows on iPad. If the arrow direction is down, so the positioning for the arrow is on top from the button and not in the middle or if the arrow direction is up, the positioning is on the bottom. 

before:
![bildschirmfoto 2015-01-16 um 10 09 38](https://cloud.githubusercontent.com/assets/7832193/5773891/09fe2f32-9d68-11e4-849a-a2bed6c403d9.png)

after:
![bildschirmfoto 2015-01-16 um 10 08 43](https://cloud.githubusercontent.com/assets/7832193/5773890/09d8df16-9d68-11e4-8f1d-0729bc6cb52d.png)
