### PR TITLE
Sets window tintColor to buttons

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -479,6 +479,20 @@ static NSUInteger PSTVisibleAlertsCount = 0;
     [self viewDidDismissWithButtonIndex:buttonIndex];
 }
 
+- (void)willPresentActionSheet:(UIActionSheet *)actionSheet {
+    for (UIView *subview in actionSheet.subviews) {
+        if ([subview isKindOfClass:[UIButton class]]) {
+            UIButton *button = (UIButton *)subview;
+            if (button.tag != (actionSheet.destructiveButtonIndex + 1)) {
+                UIColor *windowTintColor = [UIApplication sharedApplication].delegate.window.tintColor;
+                if (windowTintColor) {
+                    [button setTitleColor:windowTintColor forState:UIControlStateNormal];
+                }
+            }
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - UIAlertViewDelegate
 


### PR DESCRIPTION
If `UIWindow` has a 'tintColor' value different from `nil` on iOS 8, `UIAlertController` uses it as buttons `tintColor` for all buttons except for the destructive button. This PR intents to do the same for `UIActionSheet` on iOS 7.