### PR TITLE
Fix: showWithSender: completion block not called under iOS 7.x

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -374,6 +374,8 @@ static NSUInteger PSTVisibleAlertsCount = 0;
             [self.alertView show];
             [self moveSheetToWeakStorage];
         }
+        // This is called before the animation is complete, but at least it's called.
+        if (completion) completion();
     }
     [self setIsShowingAlert:YES];
 }


### PR DESCRIPTION
The completion block for the showWithSender: methods was being called when the alert was presented using UIAlertController (iOS 8+), but not when it was presented using UIAlertView or UIActionSheet (pre-iOS 8).

This patch ensures that the completion block gets called on pre-iOS 8 devices, although it does so before the presentation animation ends, so the behavior still isn't entirely consistent.