### PR TITLE
Added two more completion block callbacks that were missing

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -296,6 +296,7 @@ static NSUInteger PSTVisibleAlertsCount = 0;
             }
 
             if (!controller) {
+                if (completion) completion();
                 NSLog(@"Can't show alert because there is no root view controller.");
                 return;
             }
@@ -360,6 +361,7 @@ static NSUInteger PSTVisibleAlertsCount = 0;
             // Will not be called if presenting fails because another present/dismissal already happened during that runloop.
             // rdar://problem/19045528
             objc_setAssociatedObject(controller, _cmd, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            if (completion) completion();
         }];
 
     } else {


### PR DESCRIPTION
Two other code paths in showWithSender:controller:animated:completion: weren't calling the completion block.  Here's a fix.