### PR TITLE
the alert can't be showed when the frontmost viewController is begin dissmissed

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -287,6 +287,9 @@ static NSUInteger PSTVisibleAlertsCount = 0;
 
             // Use the frontmost viewController for presentation.
             while (controller.presentedViewController) {
+                if([controller.presentedViewController isBeingDismissed]) {
+                    break;
+                }
                 controller = controller.presentedViewController;
             }
 


### PR DESCRIPTION
the alert can't be showed when the frontmost viewController is begin dissmissed