### PR TITLE
Fix memory leak with PSTAlertController

### DIFF
--- a/PSTAlertController/PSTAlertController.m
+++ b/PSTAlertController/PSTAlertController.m
@@ -347,6 +347,9 @@ static NSUInteger PSTVisibleAlertsCount = 0;
         alertController.viewDidDisappearBlock = ^{
             typeof (self) strongSelf = weakSelf;
             [strongSelf performBlocks:PROPERTY(didDismissBlocks) withAction:strongSelf.executedAlertAction];
+
+            // to avoid holding self too long time
+            objc_setAssociatedObject(controller, _cmd, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         };
 
         [controller presentViewController:alertController animated:animated completion:^{


### PR DESCRIPTION
We find that PSTAlertController will cause memory leak due to hold the PSTAlertContoller object by the related ViewController or the front most ViewController through objc_setAssociatedObject. Maybe reset it when the UIAlertController dismisses is safe enough.